### PR TITLE
Update constants

### DIFF
--- a/custom_components/midea_dehumidifier_lan/climate.py
+++ b/custom_components/midea_dehumidifier_lan/climate.py
@@ -16,10 +16,7 @@ from homeassistant.components.climate.const import (
     PRESET_ECO,
     PRESET_NONE,
     PRESET_SLEEP,
-    SUPPORT_FAN_MODE,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_SWING_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
+    ClimateEntityFeature,
     SWING_BOTH,
     SWING_HORIZONTAL,
     SWING_OFF,
@@ -131,10 +128,10 @@ class AirConditionerEntity(ApplianceEntity, ClimateEntity):
     _attr_temperature_unit = TEMP_CELSIUS
 
     _attr_supported_features = (
-        SUPPORT_TARGET_TEMPERATURE
-        | SUPPORT_FAN_MODE
-        | SUPPORT_SWING_MODE
-        | SUPPORT_PRESET_MODE
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.SWING_MODE
+        | ClimateEntityFeature.PRESET_MODE
     )
 
     _name_suffix = ""

--- a/custom_components/midea_dehumidifier_lan/climate.py
+++ b/custom_components/midea_dehumidifier_lan/climate.py
@@ -25,7 +25,7 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature.CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/custom_components/midea_dehumidifier_lan/climate.py
+++ b/custom_components/midea_dehumidifier_lan/climate.py
@@ -125,7 +125,7 @@ class AirConditionerEntity(ApplianceEntity, ClimateEntity):
     _attr_max_temp = MAX_TARGET_TEMPERATURE
     _attr_min_temp = MIN_TARGET_TEMPERATURE
     _attr_precision = PRECISION_HALVES
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE

--- a/custom_components/midea_dehumidifier_lan/climate.py
+++ b/custom_components/midea_dehumidifier_lan/climate.py
@@ -25,7 +25,7 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature.CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/custom_components/midea_dehumidifier_lan/fan.py
+++ b/custom_components/midea_dehumidifier_lan/fan.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Final
 
 from homeassistant.components.fan import (
-    SUPPORT_PRESET_MODE,
+    FanEntityFeature,
     FanEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -52,7 +52,7 @@ async def async_setup_entry(
 class DehumidiferFan(ApplianceEntity, FanEntity):
     """Entity for managing dehumidifer fan"""
 
-    _attr_supported_features = SUPPORT_PRESET_MODE
+    _attr_supported_features = FanEntityFeature.PRESET_MODE
     _attr_preset_modes = PRESET_MODES_7
     _attr_speed_count = len(PRESET_MODES_7)
     _name_suffix = " Fan"

--- a/custom_components/midea_dehumidifier_lan/humidifier.py
+++ b/custom_components/midea_dehumidifier_lan/humidifier.py
@@ -4,7 +4,7 @@ import logging
 from typing import Final
 
 from homeassistant.components.humidifier import HumidifierDeviceClass, HumidifierEntity
-from homeassistant.components.humidifier.const import SUPPORT_MODES
+from homeassistant.components.humidifier.const import HumidifierEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -71,7 +71,7 @@ class DehumidifierEntity(ApplianceEntity, HumidifierEntity):
     _attr_device_class = HumidifierDeviceClass.DEHUMIDIFIER
     _attr_max_humidity = MAX_TARGET_HUMIDITY
     _attr_min_humidity = MIN_TARGET_HUMIDITY
-    _attr_supported_features = SUPPORT_MODES
+    _attr_supported_features = HumidifierEntityFeature.MODES
     _name_suffix = ""
     _add_extra_attrs = True
 

--- a/custom_components/midea_dehumidifier_lan/sensor.py
+++ b/custom_components/midea_dehumidifier_lan/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -63,7 +63,7 @@ class CurrentTemperatureSensor(ApplianceEntity, SensorEntity):
     """Current environment temperature sensor"""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _name_suffix = " Temperature"
 
@@ -92,7 +92,7 @@ class OutsideTemperatureSensor(ApplianceEntity, SensorEntity):
     """Current outside temperature sensor"""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _unique_id_prefx = UNIQUE_CLIMATE_PREFIX
     _name_suffix = " Outdoor Temperature"


### PR DESCRIPTION
Since 2024.1 Home Assistant update, the integration no longer works.

As of Home Assistant Core 2022.5, all SUPPORT_* constants are deprecated, each entity platform is providing an EntityFeature enum to replace them.

https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/