### PR TITLE
Add icons for Fan and Dehumidifier modes

### DIFF
--- a/custom_components/midea_dehumidifier_lan/fan.py
+++ b/custom_components/midea_dehumidifier_lan/fan.py
@@ -78,6 +78,10 @@ class DehumidiferFan(ApplianceEntity, FanEntity):
     def is_on(self):
         # Override parent logic
         return self._attr_is_on
+    
+    @property
+    def translation_key(self):
+        return "fan"
 
     def on_online(self, update: bool) -> None:
         supports = self.dehumidifier().capabilities

--- a/custom_components/midea_dehumidifier_lan/humidifier.py
+++ b/custom_components/midea_dehumidifier_lan/humidifier.py
@@ -81,6 +81,10 @@ class DehumidifierEntity(ApplianceEntity, HumidifierEntity):
         self._attr_mode = None
         self._attr_available_modes = [MODE_SET]
 
+    @property
+    def translation_key(self):
+        return "dehumidifier"
+
     def on_online(self, update: bool) -> None:
         capabilities = self.coordinator.appliance.state.capabilities
 

--- a/custom_components/midea_dehumidifier_lan/icons.json
+++ b/custom_components/midea_dehumidifier_lan/icons.json
@@ -1,0 +1,39 @@
+{
+    "entity": {
+        "fan": {
+            "fan": {
+                "default": "mdi:fan",
+                "state_attributes": {
+                    "preset_mode": {
+                        "default": "mdi:fan",
+                        "state": {
+                            "Low": "mdi:fan-speed-1",
+                            "Medium": "mdi:fan-speed-2",
+                            "High": "mdi:fan-speed-3",
+                            "Auto": "mdi:fan-auto"
+                        }
+                    }
+                }
+            }
+        },
+        "humidifier": {
+            "dehumidifier": {
+                "default": "mdi:air-humidifier",
+                "state_attributes": {
+                    "mode": {
+                        "default": "mdi:fan",
+                        "state": {
+                            "Set": "mdi:thermostat",
+                            "Continuous": "mdi:cached",
+                            "Dry": "mdi:water-off",
+                            "Smart": "mdi:lightbulb-on",
+                            "Purifier": "mdi:air-purifier",
+                            "Antimould": "mdi:bacteria-outline",
+                            "Fan": "mdi:fan"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Define icons for the modes so that the new [features](https://www.home-assistant.io/dashboards/features/) for fan/humidifier cards look pretty.
![image](https://github.com/user-attachments/assets/4588d091-10d4-4dc5-ba5c-e6938af643a6)
Resolves #171 although I did not implement icons for climate entities as I don't have an air condition on hand to test but it should be pretty simple to add!