### PR TITLE
Tidy dependency specification

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -8,4 +8,4 @@ cd "$(dirname "$0")/.."
 touch custom_components/__init__.py
 
 # Install requirements
-python3 -m pip install --requirement requirements.txt
+python3 -m pip install --requirement requirements-test.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,11 @@
-packaging==23.2
+-r requirements.txt
 pre-commit~=3.5
 PyGithub~=2.1
 pyupgrade~=3.15
 yamllint~=1.33
+flake8~=6.1
+flake8-docstrings~=1.7
+mypy==1.7.0
+pylint~=3.0
+pylint-strict-informational==0.1
+ruff~=0.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,12 +1,5 @@
 -r requirements-dev.txt
 asynctest~=0.13
-flake8~=6.1
-flake8-docstrings~=1.7
-mypy==1.7.0
-pylint~=3.0
-pylint-strict-informational==0.1
 pytest>=7.2
 pytest-cov>=3.0
 pytest-homeassistant-custom-component>=0.12
-tzdata
-ruff~=0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pip>=21.0,<23.4
 colorlog
 homeassistant>=2023.7.0
+tzdata


### PR DESCRIPTION
- Setup dev container test as we can then run tests from within there
- Add dependency on base requirements to dev file to allow full dependency installation
- Move linters from test requirements to dev requirements
- Move tzdata to base requirements
- Remove:
  - pip -  don't think we need this?
  - packaging - couldn't see a need for this one too?
