### PR TITLE
Add bump CI pipeline

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 0.9.4
-tag = True
-commit = True
-
-[bumpversion:file:custom_components/midea_dehumidifier_lan/manifest.json]
-
-[bumpversion:file:custom_components/midea_dehumidifier_lan/const.py]

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -20,4 +20,3 @@ filename = "custom_components/midea_dehumidifier_lan/manifest.json"
 
 [[tool.bumpversion.files]]
 filename = "custom_components/midea_dehumidifier_lan/const.py"
-

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,23 @@
+[tool.bumpversion]
+current_version = "0.9.6"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+ignore_missing_files = false
+tag = true
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = false
+commit = true
+message = "Bump version: {current_version} → {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "custom_components/midea_dehumidifier_lan/manifest.json"
+
+[[tool.bumpversion.files]]
+filename = "custom_components/midea_dehumidifier_lan/const.py"
+

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,6 +13,9 @@ on:
         - minor
         - patch
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
           BUMPVERSION_TAG: "true"
         with:
           args: ${{ inputs.bump-type }}
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check
         if: steps.bump.outputs.bumped == 'true'

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,35 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump-type:
+        description: 'Bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - major
+        - minor
+        - patch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Bump version
+        id: bump
+        uses: callowayproject/bump-my-version@1.1.2
+        env:
+          BUMPVERSION_TAG: "true"
+        with:
+          args: ${{ inputs.bump-type }}
+          github-token: ${{ secrets.GH_TOKEN }}
+
+      - name: Check
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pre-commit~=3.5
 PyGithub~=2.1
 pyupgrade~=3.15
 yamllint~=1.33
+bump-my-version==1.1.2


### PR DESCRIPTION
Saw you were using bump-my-version

- Migrate config to toml (cfg was deprecated)
- Fix version with released
- Add pipeline to trigger release (there will be a drop down on the action to start)


Perhaps we should also create the release with something like this https://github.com/ghalactic/github-release-from-tag?

## Update

Looks like we wont be able to easily trigger another pipeline due to permissions of the token. unless you go down the PAT route.

See: https://github.com/orgs/community/discussions/27028#discussioncomment-3254360