### PR TITLE
Fix removed hass.components.persistent_notification API (HA 2026.x)

### DIFF
--- a/custom_components/midea_dehumidifier_lan/appliance_discovery.py
+++ b/custom_components/midea_dehumidifier_lan/appliance_discovery.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
 )
 from homeassistant.core import CALLBACK_TYPE
+from homeassistant.components import persistent_notification
 from homeassistant.helpers.event import async_track_time_interval
 from midea_beautiful.lan import LanDevice
 
@@ -124,7 +125,8 @@ class ApplianceDiscoveryHelper:  # pylint: disable=too-many-instance-attributes
             f"Found previously unknown device {name} found on {new.address}."
             f" [Check it out.](/config/integrations)"
         )
-        self.hass.components.persistent_notification.async_create(
+        persistent_notification.async_create(
+            self.hass,
             title=NAME,
             message=msg,
             notification_id=f"midea_unknown_{new.serial_number}",
@@ -161,7 +163,8 @@ class ApplianceDiscoveryHelper:  # pylint: disable=too-many-instance-attributes
                     "name": known[CONF_NAME],
                     "address": new.address,
                 }
-                self.hass.components.persistent_notification.async_create(
+                persistent_notification.async_create(
+                    self.hass,
                     title=NAME,
                     message=msg,
                     notification_id=f"midea_wait_discovery_{new.serial_number}",
@@ -201,7 +204,8 @@ class ApplianceDiscoveryHelper:  # pylint: disable=too-many-instance-attributes
                 "address": address,
             }
 
-            self.hass.components.persistent_notification.async_create(
+            persistent_notification.async_create(
+                self.hass,
                 title=NAME,
                 message=msg,
                 notification_id=f"midea_non_lan_discovery_{device.serial_number}",


### PR DESCRIPTION
Fixes #248

Fixes the discovery crash where appliances are found on the LAN but never activated on Home Assistant 2026.x.

`hass.components` was removed from HA, so `self.hass.components.persistent_notification.async_create(...)` raises `AttributeError`. It fires in `_admitted_known_device` (the `WAIT → LAN` promotion path), so cloud-registered appliances discovered later on the LAN never get devices/entities created.

This switches the 3 call sites to the documented `homeassistant.components.persistent_notification.async_create(hass, ...)`.

Tested on HA 2026.5.4 / Python 3.14: with this change appliances are promoted from `WAIT` to `LAN` and entities are created.

Complements #246 (which fixes the separate `OptionsFlow.config_entry` crash but doesn't touch `appliance_discovery.py`).
